### PR TITLE
Add nginx load balancer and update compose

### DIFF
--- a/Order-ms/src/main/java/com/neman/orderms/Client/ProductClient.java
+++ b/Order-ms/src/main/java/com/neman/orderms/Client/ProductClient.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
 
-@FeignClient(name = "product-service", path = "/api/v1/products", url = "http://localhost:5020")
+@FeignClient(name = "product-service", path = "/api/v1/products", url = "${PRODUCT_SERVICE_URL:http://nginx:5020}")
 public interface ProductClient {
 
     @GetMapping("/get/{id}")

--- a/Order-ms/src/main/java/com/neman/orderms/Client/UserClient.java
+++ b/Order-ms/src/main/java/com/neman/orderms/Client/UserClient.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "user-service", path = "/api/v1/users", url = "http://localhost:5010")
+@FeignClient(name = "user-service", path = "/api/v1/users", url = "${USER_SERVICE_URL:http://nginx:5010}")
 public interface  UserClient {
 
     @GetMapping("/getUser/{id}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,9 +61,8 @@ services:
     build:
       context: ./user-ms/build/docker
       dockerfile: Dockerfile
-    container_name: user-service
-    ports:
-      - "6010:6010"
+    expose:
+      - "5010"
     depends_on:
       user-db:
         condition: service_healthy
@@ -75,7 +74,7 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6010/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5010/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -84,9 +83,8 @@ services:
     build:
       context: ./order-ms/build/docker
       dockerfile: Dockerfile
-    container_name: order-service
-    ports:
-      - "6030:6030"
+    expose:
+      - "5040"
     depends_on:
       order-db:
         condition: service_healthy
@@ -96,10 +94,12 @@ services:
       DB_CONNECTION_PORT: 3306
       DB_CONNECTION_USERNAME: order
       DB_CONNECTION_PASSWORD: password
+      USER_SERVICE_URL: http://nginx:5010
+      PRODUCT_SERVICE_URL: http://nginx:5020
     networks:
       - app-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6030/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5040/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -108,9 +108,8 @@ services:
     build:
        context: ./product-ms/build/docker
        dockerfile: Dockerfile
-    container_name: product-service
-    ports:
-      - "6020:6020"
+    expose:
+      - "5020"
     depends_on:
       product-db:
         condition: service_healthy
@@ -122,10 +121,21 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6020/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5020/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 5
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "5010:5010"
+      - "5020:5020"
+      - "5040:5040"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - app-network
 
 
 networks:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,37 @@
+# Nginx load balancer configuration
+
+upstream user_service {
+    server user-service-1:5010;
+    server user-service-2:5010;
+}
+
+upstream product_service {
+    server product-service-1:5020;
+    server product-service-2:5020;
+}
+
+upstream order_service {
+    server order-service-1:5040;
+    server order-service-2:5040;
+}
+
+server {
+    listen 5010;
+    location / {
+        proxy_pass http://user_service;
+    }
+}
+
+server {
+    listen 5020;
+    location / {
+        proxy_pass http://product_service;
+    }
+}
+
+server {
+    listen 5040;
+    location / {
+        proxy_pass http://order_service;
+    }
+}

--- a/read.me
+++ b/read.me
@@ -1,0 +1,27 @@
+# Microservice Project
+
+This project uses Docker Compose for local orchestration. An Nginx container routes traffic to the individual services.
+
+## Running
+
+```bash
+docker-compose up --build
+```
+
+### Scaling services
+
+Each service can be scaled using Compose:
+
+```bash
+docker-compose up --scale user-service=2 --scale product-service=2 --scale order-service=2
+```
+
+Nginx will automatically proxy requests to the available instances on the network. Requests should be sent to:
+
+- `http://localhost:5010` for **user-service**
+- `http://localhost:5020` for **product-service**
+- `http://localhost:5040` for **order-service**
+
+## Configuration
+
+Order service resolves other services via the environment variables `USER_SERVICE_URL` and `PRODUCT_SERVICE_URL`. Defaults point at the `nginx` container.


### PR DESCRIPTION
## Summary
- introduce nginx with upstream configuration for user/product/order services
- allow microservices to scale by removing fixed container names and exposing internal ports
- route service calls in Order-ms through configuration properties
- document how to run and scale services via nginx

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68455ecea51c83309b14361c8d3b1917